### PR TITLE
Fix compare method edge case bugs

### DIFF
--- a/lib/compare.rb
+++ b/lib/compare.rb
@@ -47,15 +47,20 @@ class Compare
 
   def character_match(user_input)
     user_guess = user_input.split("")
-    sequence & user_guess
+    #binding.pry
+    (sequence & user_guess).flat_map do |character|
+      [character] * [sequence.count(character), user_guess.count(character)].min
+    end
   end
 
   def index_match(user_input)
     user_guess = user_input.split("")
     matched_characters = @sequence.zip(user_guess)
-    matched_characters.find_all do |matched_characters|
-      matched_characters[0] == matched_characters[1]
-    end
+    matched_characters.map do |matched_character|
+      if matched_character[0] == matched_character[1]
+        matched_character[0]
+      end
+    end.flatten.compact
   end
 
   def user_won?(user_input)

--- a/spec/compare_spec.rb
+++ b/spec/compare_spec.rb
@@ -114,12 +114,18 @@ RSpec.describe Compare do
     compare = Compare.new(['y', 'b', 'y', 'b'])
 
     expect(compare.character_match('grby')).to eq(['y', 'b'])
+
+    compare = Compare.new(['b', 'g', 'r', 'b'])
+
+    expect(compare.character_match('bbyb')).to eq(['b', 'b'])
   end
 
   it 'can find matching indexes' do
     compare = Compare.new(['r', 'g', 'y', 'b'])
 
     expect(compare.index_match('rrby')).to eq(['r'])
+    expect(compare.index_match('rryy')).to eq(['r', 'y'])
+    expect(compare.index_match('bbyg')).to eq(['y'])
   end
 
   it 'can determine if user guess is correct' do


### PR DESCRIPTION
What I did:
- index match was returning duplicate characters, added an if statement, flatten method, and compact method as well as changed find_all to map. 
- character match was not returning enough characters when there were multiple of the same characters on both the guess and the sequence. google search led me to using a mixture of intersect, flat_map, count, and min

Roadblocks:
- I read that compact shouldn't really be used except in emergencies... since we're low on time and I couldn't think of another solution I feel like it's what we have right now. the map returns nils if I don't use the compact method, and I don't know how to get the right characters into map without an if statement. find_all was returning duplicates. 

